### PR TITLE
fix: (googleTranlator) avoid translateBatch fails

### DIFF
--- a/src/dolmetscher.js
+++ b/src/dolmetscher.js
@@ -114,16 +114,18 @@ class GoogleTranslator extends BaseTranslator {
 
   async translateBatch(texts) {
     const arr = [];
-
-    try {
       for (const text of texts) {
-        const res = await this.translateText(text);
-        arr.push(res);
+        try {
+          const res = await this.translateText(text);
+          arr.push({ traduction: res });
+        } catch (err) {
+          arr.push(
+            {
+              text,
+              error: `error translating batch: ${err}`
+            });
+        }
       }
-    } catch (err) {
-      throw `error translating batch: ${err}`;
-    }
-
     return arr;
   }
 


### PR DESCRIPTION
This change do:

- For translateBatch() on GoogleTranslator: 
- [x] avoid fails if any element fails
- [x] array with same numbers of elements must be returned
- [x] errors must be captured and returned

- [x] pendent do the same on MymemoryTranslator

related issue: #11 